### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,3 +1,4 @@
+---
 name: CI
 
 on:
@@ -7,19 +8,18 @@ on:
     branches: [ main ]
 
 jobs:
-
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.15
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
 
-    - name: Build
-      run: go build -v ./...
+      - name: Build
+        run: go build
 
-    - name: Test
-      run: go test -v ./...
+      - name: Test
+        run: go test -v ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+---
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+
+      - name: Build Windows
+        run: env GOOS=windows GOARCH=amd64 go build -o solo.linux-amd64.exe
+      - name: Build Mac
+        run: env GOOS=darwin GOARCH=amd64 go build -o solo.darwin-amd64
+      - name: Build Linux
+        run: env GOOS=linux GOARCH=amd64 go build -o solo.linux-amd64
+
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: false
+          files: |
+            solo.*
+            LICENSE
+            README.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .vscode/
 
 /solo
-/solo.exe
+/solo.*


### PR DESCRIPTION
Creates a release when you push a tag starting with "v". I couldn't find an easy way to store the version in the repo or automatically increment a number, but we can add that later if needed.

Tested by pushing the `v0.0.1-unstable` tag which produced this release: https://github.com/SoloDeploy/solo/releases/tag/v0.0.1-unstable 